### PR TITLE
Correct order of precedence

### DIFF
--- a/RobocopyPS/functions/Invoke-RoboCopy.ps1
+++ b/RobocopyPS/functions/Invoke-RoboCopy.ps1
@@ -765,7 +765,7 @@ Function Invoke-RoboCopy {
             }
 
             # Arguments of the copy command. Fills in the $RoboLog temp file
-            $RoboArgs = $RobocopyArguments + "/bytes /TEE /np /njh /fp /ndl /ts" -split " "
+            $RoboArgs = $RobocopyArguments + ("/bytes /TEE /np /njh /fp /ndl /ts" -split " ")
 
             If ($Quit) {
                 # If Quit is used output parameters and break


### PR DESCRIPTION
Split will get executed after the append action.
The intended action is to split the  string of arguments and then append to the current list.
This is a bug for for sources and destinations that have multiple spaces together.

The new script:
```
$source = "`"C:\test\path  with  multiple  spaces\src`""
$destination = "`"C:\test\path  with  multiple  spaces\dst`""
$RobocopyArguments = $source , $destination 
$RobocopyArguments + ("/bytes /TEE /np /njh /fp /ndl /ts /quit" -split " ")
```
Generates this output:
```
"C:\test\path  with  multiple  spaces\src"
"C:\test\path  with  multiple  spaces\dst"
/bytes
/TEE
/np
/njh
/fp
/ndl
/ts
/quit
```

The old script:
```
$source = "`"C:\test\path  with  multiple  spaces\src`""
$destination = "`"C:\test\path  with  multiple  spaces\dst`""
$RobocopyArguments = $source, $destination
$RobocopyArguments + "/bytes /TEE /np /njh /fp /ndl /ts /quit" -split " "
```
Generates this output:
```
"C:\test\path

with

multiple

spaces\src"
"C:\test\path

with

multiple

spaces\dst"
/bytes
/TEE
/np
/njh
/fp
/ndl
/ts
/quit
```