### PR TITLE
Fix for changes to command line argument passing in PS 7.3.

### DIFF
--- a/RobocopyPS/functions/Invoke-RoboCopy.ps1
+++ b/RobocopyPS/functions/Invoke-RoboCopy.ps1
@@ -852,6 +852,10 @@ Function Invoke-RoboCopy {
         # Arguments of the copy command. Fills in the $RoboLog temp file
         $RoboArgs = @($RobocopyArguments + ('/bytes', '/TEE', '/np', '/njh', '/fp', '/ndl', '/ts'))
 
+        # Powershell 7.3 introduces breaking changes to argument passing.
+        # https://learn.microsoft.com/en-us/powershell/scripting/learn/experimental-features?view=powershell-7.3#psnativecommandargumentpassing
+        $PSNativeCommandArgumentPassing = 'Legacy'
+
         # Reason why ShouldProcess is this far down is because $action is not set before this part
         $strRoboArgs = ($RoboArgs | ForEach-Object { [string]$_ }) -join ' '
         If ($PSCmdlet.ShouldProcess("$Destination from $Source" , "$action with arguments $strRoboArgs")) {

--- a/RobocopyPS/functions/Invoke-RoboCopy.ps1
+++ b/RobocopyPS/functions/Invoke-RoboCopy.ps1
@@ -854,7 +854,7 @@ Function Invoke-RoboCopy {
 
         # Powershell 7.3 introduces breaking changes to argument passing.
         # https://learn.microsoft.com/en-us/powershell/scripting/learn/experimental-features?view=powershell-7.3#psnativecommandargumentpassing
-        $PSNativeCommandArgumentPassing = 'Legacy'
+        $script:PSNativeCommandArgumentPassing = 'Legacy'
 
         # Reason why ShouldProcess is this far down is because $action is not set before this part
         $strRoboArgs = ($RoboArgs | ForEach-Object { [string]$_ }) -join ' '


### PR DESCRIPTION
Powershell 7.3 introduces changes that breaks argument passing to Robocopy.exe.
This pull request sets the PSNativeCommandArgumentPassing variable to legacy parsing.

Previous versions of Powershell should simply ignore the setting, so this should be a
harmless change.